### PR TITLE
Add swap memory size threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ whacamole
 [![Build Status](https://travis-ci.org/arches/whacamole.png)](https://travis-ci.org/arches/whacamole)
 
 Whacamole keeps track of your Heroku dynos' memory usage and restarts large dynos before they start
-swapping to disk (aka get super slow).
+swapping to disk (aka get super slow) or when the swap size exceeds a certain limit.
 
 Here’s what Heroku says about dyno memory usage:
 
@@ -50,7 +50,7 @@ end
 Whacamole.configure("HEROKU APP WITH MULTIPLE DYNO TYPES") do |config|
   config.api_token = ENV['HEROKU_API_TOKEN'] # you could also paste your token in here as a string
   config.dynos = %w{web worker}
-  config.restart_threshold = 500 # in megabytes. default is 1000 (good for 2X dynos)
+  config.restart_threshold = { total: 500, swap: 50 } # in megabytes. default is 1000 for total (good for 2X dynos), nil for swap
 end
 ```
 
@@ -76,7 +76,8 @@ Each ping and restart is available to you, for example in case you want to see w
 
 Methods on DynoSize events
  * event.process (the heroku process, eg "web.1")
- * event.size (dyno size, eg 444.06)
+ * event.total_size (dyno size, eg 444.06)
+ * event.swap_size (swap size, eg 12.01)
  * event.units (units for the size, eg "MB")
 
 Methods on DynoRestart events

--- a/lib/whacamole/config.rb
+++ b/lib/whacamole/config.rb
@@ -1,7 +1,7 @@
 module Whacamole
   class Config
 
-    RESTART_THRESHOLD = 1000
+    RESTART_TOTAL_THRESHOLD = 1000
     RESTART_RATE_LIMIT = 30*60
 
     attr_accessor :app_name, :api_token, :event_handler, :dynos, :restart_threshold, :restart_window
@@ -10,8 +10,18 @@ module Whacamole
       self.app_name = app_name
       self.event_handler ||= lambda { |e| puts e.inspect.to_s }
       self.dynos ||= %w{web}
-      self.restart_threshold ||= RESTART_THRESHOLD
+      self.restart_threshold = {total: RESTART_TOTAL_THRESHOLD}
       self.restart_window ||= RESTART_RATE_LIMIT
     end
+
+    def restart_threshold=(value)
+      if value.is_a? Integer
+        warn "[DEPRECATION] `restart_threshold` should be supplied as a hash. ex.: {total: 500}"
+        @restart_threshold = { total: value }
+      else
+        @restart_threshold = value
+      end
+    end
+
   end
 end

--- a/lib/whacamole/events.rb
+++ b/lib/whacamole/events.rb
@@ -12,10 +12,14 @@ module Whacamole
 
     class DynoSize < Event
       attr_accessor :units
-      attr_reader :size
+      attr_reader :total_size, :swap_size
 
-      def size=(size)
-        @size = size.to_f
+      def total_size=(size)
+        @total_size = size.to_f if size
+      end
+
+      def swap_size=(size)
+        @swap_size = size.to_f if size
       end
     end
 

--- a/lib/whacamole/stream.rb
+++ b/lib/whacamole/stream.rb
@@ -25,8 +25,8 @@ module Whacamole
     end
 
     def dispatch_handlers(chunk)
-      memory_size_from_chunk(chunk).each do |dyno, size|
-        event = Events::DynoSize.new({:process => dyno, :size => size, :units => "MB"})
+      memory_size_from_chunk(chunk).each do |dyno, total_size, swap_size|
+        event = Events::DynoSize.new({:process => dyno, :total_size => total_size, :swap_size => swap_size, :units => "MB"})
         event_handler.call(event)
 
         restart(event.process) if restart_necessary?(event)
@@ -45,27 +45,44 @@ module Whacamole
     end
 
     def restart_necessary?(event)
-      event.size > restart_threshold
+      total_threshold_exceeded?(event) || swap_threshold_exceeded?(event)
+    end
+
+    def total_threshold_exceeded?(event)
+      event.total_size && event.total_size > restart_threshold[:total]
+    end
+
+    def swap_threshold_exceeded?(event)
+      restart_threshold[:swap] && event.swap_size && event.swap_size > restart_threshold[:swap]
     end
 
     def memory_size_from_chunk(chunk)
       sizes = []
-      dynos_regexp = Regexp.new('(' + @dynos.join('|') + ')\.\d+')
+      dynos_regexp   = Regexp.new('(' + @dynos.join('|') + ')\.\d+')
+      measure_regexp = Regexp.new("measure=(memory_total|memory_swap)")
 
       # new log format
       chunk.split("\n").select{|line| line.include? "sample#memory_total"}.each do |line|
         dyno = line.match(dynos_regexp)
         next unless dyno
-        size = line.match(/sample#memory_total=([\d\.]+)/)
-        sizes << [dyno[0], size[1]] unless size.nil?
+        total_size = line.match(/sample#memory_total=([\d\.]+)/)
+        swap_size = line.match(/sample#memory_swap=([\d\.]+)/)
+        sizes << [dyno[0], total_size[1], swap_size[1]] unless total_size.nil?
       end
 
       # old log format
-      chunk.split("\n").select{|line| line.include? "measure=memory_total"}.each do |line|
+      chunk.split("\n").select{|line| line.match measure_regexp }.each do |line|
         dyno = line.match(dynos_regexp)
         next unless dyno
-        size = line.match(/val=([\d\.]+)/)
-        sizes << [dyno[0], size[1]] unless size.nil?
+        memory_type = line.match(measure_regexp)
+        total_size = line.match(/val=([\d\.]+)/)
+        unless total_size.nil?
+          if memory_type[1] == 'memory_total'
+            sizes << [dyno[0], total_size[1], nil]
+          elsif memory_type[1] == 'memory_swap'
+            sizes << [dyno[0], nil, total_size[1]]
+          end
+        end
       end
 
       sizes

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -12,9 +12,20 @@ describe Whacamole::Config do
       c.dynos.should == %w{web}
     end
 
-    it "has a default restart_threshold" do
+    it "has a default total restart threshold" do
       c = Whacamole::Config.new("production")
-      c.restart_threshold.should == 1000
+      c.restart_threshold[:total].should == 1000
+    end
+
+    it "can be set with a legacy restart treshold value" do
+      c = Whacamole::Config.new("production")
+      c.restart_threshold = 500
+      c.restart_threshold.should == {total: 500}
+    end
+
+    it "has no swap restart threshold" do
+      c = Whacamole::Config.new("production")
+      c.restart_threshold[:swap].should == nil
     end
   end
 end

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -3,10 +3,17 @@ require 'spec_helper'
 describe "DynoSize" do
   let (:e) { Whacamole::Events::DynoSize.new }
 
-  describe "setting size" do
+  describe "setting total_size" do
     it "converts strings to floats" do
-      e.size = "766.65"
-      e.size.should == 766.65
+      e.total_size = "766.65"
+      e.total_size.should == 766.65
+    end
+  end
+
+  describe "setting swap_size" do
+    it "does not convert nil values" do
+      e.total_size = nil
+      e.total_size.should == nil
     end
   end
 
@@ -26,8 +33,9 @@ describe "DynoSize" do
 
   describe "initialization" do
     it "sets the variables from the input hash" do
-      e = Whacamole::Events::DynoSize.new({:size => "766.65", :units => "MB", :process => "web.2"})
-      e.size.should == 766.65
+      e = Whacamole::Events::DynoSize.new({:total_size => "766.65", swap_size: "34.5", :units => "MB", :process => "web.2"})
+      e.swap_size.should == 34.5
+      e.total_size.should == 766.65
       e.units.should == "MB"
       e.process.should == "web.2"
     end

--- a/spec/whacamole_spec.rb
+++ b/spec/whacamole_spec.rb
@@ -32,12 +32,12 @@ describe Whacamole do
     it "accepts a threshold override per config" do
       Whacamole.configure("production") do |config|
         config.api_token = "prod token"
-        config.restart_threshold.should == 1000
-        config.restart_threshold = 500
+        config.restart_threshold[:total].should == 1000
+        config.restart_threshold[:total] = 500
       end
       Whacamole.configure("production") do |config|
         config.api_token = "prod token"
-        config.restart_threshold.should == 500
+        config.restart_threshold[:total].should == 500
       end
 
     end


### PR DESCRIPTION
This addresses the issue #6 where the dyno swap size should also be monitored. With this pull request, you can set a swap memory size threshold and the dyno will restart if it reaches the threshold.

I have not yet tested it in production. I added some specs though.