### PR TITLE
Add a warning about preboot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ Whacamole.configure("HEROKU APP NAME") do |config|
 end
 ```
 
+## Contraindications
+
+:warning: Whacamole should not be used when [preboot](https://devcenter.heroku.com/articles/preboot) is activated.
+
+There are 2 main issues when using Whacamole with preboot:
+* when restarting a whole app (which happens automatically at least once a day), 2 instances of the whacamole dyno are running at the same time and would thus cause a restart to be executed twice (on an app that is already restarting!)
+* when restarting a whole app or a single dyno (e.g. manually with `heroku ps:restart web.X`, whacked by Whacamole or restarted by an autoscaler), 2 instances of the dyno are running at the same time so Whacamole can receive logs of metrics from the old dyno (actually still running) and restart the new dyno (possibly still booting and that would actually not need to be restarted)
+
 ## Self Promotion
 
 If you like Whacamole, help spread the word! Tell your friends, or at the very least star the repo on github.


### PR DESCRIPTION
This PR adds a warning in README about using Whacamole on an application that has [preboot](https://devcenter.heroku.com/articles/preboot) enabled.

We've seen some weirdness on a 30+ dynos app and Heroku support engineer @watsonian found this out (all credit goes to him, actually):
> It looks like Whacamole might not be behaving well with preboot. The problem is that there's a 3 minute period where both the old and new dynos are running. The old dyno is still processing requests while the new dyno is booting. The memory usage log emissions that Whacamole is seeing are from the old dyno, not the new dyno. Whacamole is then restarting your dyno even though it's already in the process of rebooting. This leaves your old original dyno (that's swapping) running for even longer because the new restart spins up yet another dyno to preboot (which takes ~3 minutes).

Note that the second issue I mention here might possibly be fixed by maintaining a trace of not only the dyno name (`web.X`) but also their unique id (`dyno=heroku.28023208.ab6ae82e-64b3-41e0-84d5-dc35124b113d` in the logs).