### PR TITLE
Handle null bytes in log stream that signal stream failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - jruby-19mode
-  - rbx-19mode
+  - 2.5
+  - 2.6
+  - 2.7
+  - jruby
+  - rbx
+before_install:
+  - gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gemspec :name => 'whacamole'
+gemspec name: 'whacamole'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,23 +6,28 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.4)
-    rake (10.1.0)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.5)
-    rspec-expectations (2.14.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.3)
+    diff-lcs (1.4.4)
+    rake (13.0.1)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake (~> 10.1)
-  rspec (~> 2.11)
+  rake (~> 13.0)
+  rspec (~> 3.9)
   whacamole!
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    whacamole (1.1.0)
+    whacamole (1.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -24,3 +24,6 @@ DEPENDENCIES
   rake (~> 10.1)
   rspec (~> 2.11)
   whacamole!
+
+BUNDLED WITH
+   2.1.4

--- a/lib/whacamole.rb
+++ b/lib/whacamole.rb
@@ -4,17 +4,18 @@ require 'whacamole/heroku_wrapper'
 require 'whacamole/stream'
 
 module Whacamole
+  extend self
 
-  @@config = {}
+  @config = {}
 
-  def self.configure(app_name)
-    @@config[app_name.to_s] ||= Config.new(app_name)
-    yield @@config[app_name.to_s]
+  def configure(app_name)
+    @config[app_name.to_s] ||= Config.new(app_name)
+    yield @config[app_name.to_s]
   end
 
-  def self.monitor
+  def monitor
     threads = []
-    @@config.each do |app_name, config|
+    @config.each do |app_name, config|
       threads << Thread.new do
         heroku = HerokuWrapper.new(app_name, config.api_token, config.dynos, config.restart_window)
 

--- a/lib/whacamole.rb
+++ b/lib/whacamole.rb
@@ -14,17 +14,31 @@ module Whacamole
   end
 
   def monitor
-    threads = []
-    @config.each do |app_name, config|
-      threads << Thread.new do
-        heroku = HerokuWrapper.new(app_name, config.api_token, config.dynos, config.restart_window)
+    @config.map { |app_name, config| build_monitor_thread app_name, config }
+           .map(&:join)
+    puts 'Monitor threads all terminated'
+  end
 
-        while true
+  private
+
+  def build_monitor_thread(app_name, config)
+    Thread.new do
+      puts 'New monitor thread started'
+      heroku = HerokuWrapper.new(app_name, config.api_token, config.dynos, config.restart_window)
+
+      while true
+        begin
+          puts 'Creating new Heroku log session'
           stream_url = heroku.create_log_session
+          puts 'Starting new log stream'
           Stream.new(stream_url, heroku, config.restart_threshold, &config.event_handler).watch
+        rescue Whacamole::Stream::StreamFailure
+          puts 'Heroku log stream sending only null bytes; creating new log session'
+          next
         end
       end
+
+      puts 'Terminating monitor thread'
     end
-    threads.collect(&:join)
   end
 end

--- a/lib/whacamole/heroku_wrapper.rb
+++ b/lib/whacamole/heroku_wrapper.rb
@@ -19,8 +19,8 @@ module Whacamole
       req['Authorization'] = authorization
       req['Content-type'] = content_type
       req['Accept'] = accept
-      req.set_form_data({'tail' => true})
-      res = Net::HTTP.start(uri.host, uri.port, :use_ssl => (uri.scheme == "https")) {|http| http.request(req)}
+      req.set_form_data({tail: true})
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == "https")) {|http| http.request(req)}
       JSON.parse(res.body)['logplex_url']
     end
 
@@ -36,7 +36,7 @@ module Whacamole
       req['Authorization'] = authorization
       req['Content-type'] = content_type
       req['Accept'] = accept
-      res = Net::HTTP.start(uri.host, uri.port, :use_ssl => (uri.scheme == "https")) {|http| http.request(req)}
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == "https")) {|http| http.request(req)}
 
       restarts[process] = Time.now
 

--- a/lib/whacamole/stream.rb
+++ b/lib/whacamole/stream.rb
@@ -4,6 +4,8 @@ module Whacamole
 
   class Stream
 
+    STREAM_DEATH = "\x00".freeze
+
     class StreamFailure < StandardError; end
 
     def initialize(url, restart_handler, config_restart_threshold, &blk)
@@ -27,7 +29,7 @@ module Whacamole
     end
 
     def dispatch_handlers(chunk)
-      raise StreamFailure if chunk == "\x00"
+      raise StreamFailure if chunk == STREAM_DEATH
 
       memory_size_from_chunk(chunk).each do |dyno, size|
         event = Events::DynoSize.new({ process: dyno, size: size, units: "MB" })

--- a/lib/whacamole/stream.rb
+++ b/lib/whacamole/stream.rb
@@ -4,6 +4,8 @@ module Whacamole
 
   class Stream
 
+    class StreamFailure < StandardError; end
+
     def initialize(url, restart_handler, config_restart_threshold, &blk)
       @url = url
       @restart_handler = restart_handler
@@ -25,6 +27,8 @@ module Whacamole
     end
 
     def dispatch_handlers(chunk)
+      raise StreamFailure if chunk == "\x00"
+
       memory_size_from_chunk(chunk).each do |dyno, size|
         event = Events::DynoSize.new({ process: dyno, size: size, units: "MB" })
         event_handler.call(event)

--- a/lib/whacamole/stream.rb
+++ b/lib/whacamole/stream.rb
@@ -14,7 +14,7 @@ module Whacamole
 
     def watch
       uri = URI(url)
-      Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
         request = Net::HTTP::Get.new(uri.request_uri)
         http.request(request) do |response|
           response.read_body do |chunk|
@@ -26,7 +26,7 @@ module Whacamole
 
     def dispatch_handlers(chunk)
       memory_size_from_chunk(chunk).each do |dyno, size|
-        event = Events::DynoSize.new({:process => dyno, :size => size, :units => "MB"})
+        event = Events::DynoSize.new({ process: dyno, size: size, units: "MB" })
         event_handler.call(event)
 
         restart(event.process) if restart_necessary?(event)
@@ -40,7 +40,7 @@ module Whacamole
       restarted = restart_handler.restart(process)
 
       if restarted
-        event_handler.call( Events::DynoRestart.new({:process => process}) )
+        event_handler.call( Events::DynoRestart.new({ process: process }) )
       end
     end
 

--- a/spec/heroku_wrapper_spec.rb
+++ b/spec/heroku_wrapper_spec.rb
@@ -6,13 +6,13 @@ describe Whacamole::HerokuWrapper do
 
   describe "dynos" do
     it "returns dyno types to monitor as given to initialize" do
-      h.dynos.should == %w{web worker}
+      expect(h.dynos).to contain_exactly 'web', 'worker'
     end
   end
 
   describe "authorization" do
     it "base64-encodes the api token and a preceding colon" do
-      h.authorization.should == "Basic OmZvb2Jhcg=="
+      expect(h.authorization).to eq "Basic OmZvb2Jhcg=="
     end
   end
 
@@ -23,9 +23,9 @@ describe Whacamole::HerokuWrapper do
       req.should_receive(:[]=).with("Authorization", h.authorization)
       req.should_receive(:[]=).with("Content-type", "application/json")
       req.should_receive(:[]=).with("Accept", "application/vnd.heroku+json; version=3")
-      req.should_receive(:set_form_data).with({'tail' => true})
+      req.should_receive(:set_form_data).with({ tail: true })
       Net::HTTP.should_receive(:start).with("api.heroku.com", 443, use_ssl: true).and_return(OpenStruct.new(:body => "{\"logplex_url\": \"https://api.heroku.com/log/session/url\"}"))
-      h.create_log_session.should == "https://api.heroku.com/log/session/url"
+      expect(h.create_log_session).to eq "https://api.heroku.com/log/session/url"
     end
   end
 
@@ -37,14 +37,14 @@ describe Whacamole::HerokuWrapper do
       req.should_receive(:[]=).with("Content-type", "application/json")
       req.should_receive(:[]=).with("Accept", "application/vnd.heroku+json; version=3")
       Net::HTTP.should_receive(:start).with("api.heroku.com", 443, use_ssl: true)
-      h.restart("web.3").should be_true
+      expect(h.restart("web.3")).to be_truthy
     end
 
     it "respects the rate limit" do
       Net::HTTP::Delete.should_not_receive(:new)
 
       h.stub(:recently_restarted? => true)
-      h.restart("web.2").should be_false
+      expect(h.restart("web.2")).to be_falsey
     end
   end
 end

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -102,6 +102,12 @@ describe Whacamole::Stream do
         restart.process.should == "web.2"
       end
     end
+
+    context "when Heroku begins sending null characters (i.e., the stream dies)" do
+      it "raises a StreamFailure" do
+        expect { stream.dispatch_handlers "\x00" }.to raise_error Whacamole::Stream::StreamFailure
+      end
+    end
   end
 end
 

--- a/whacamole.gemspec
+++ b/whacamole.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.executables         = ['whacamole']
 
-  gem.add_development_dependency 'rspec', '~> 2.11'
-  gem.add_development_dependency 'rake', '~> 10.1'
+  gem.add_development_dependency 'rspec', '~> 3.9'
+  gem.add_development_dependency 'rake', '~> 13.0'
 end


### PR DESCRIPTION
Patches issue #20.

The log outages are the result of Heroku sending only null bytes.  This patch raises the problem as an exception that bubbles up to the main Whacamole loop, which catches it and starts a new log session.

I also updated the spec gems and much of the Ruby syntax.  If you'd like, I'm happy to PR a branch that _only_ addresses this issue in isolation without those updates.